### PR TITLE
Add catch parentheses

### DIFF
--- a/src/SignalR/clients/ts/signalr/src/HubConnection.ts
+++ b/src/SignalR/clients/ts/signalr/src/HubConnection.ts
@@ -653,7 +653,7 @@ export class HubConnection {
                     if (this._connectionState === HubConnectionState.Connected) {
                         try {
                             await this._sendMessage(this._cachedPingMessage);
-                        } catch {
+                        } catch (e) {
                             // We don't care about the error. It should be seen elsewhere in the client.
                             // The connection is probably in a bad or closed state now, cleanup the timer so it stops triggering
                             this._cleanupPingTimer();


### PR DESCRIPTION
When bundling SignalR on Vercel / Vite this specific line is causing a syntax error (specifically the esm version of this bundle). When adding `(e)` it works.

# {PR title}

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
